### PR TITLE
feat: ngModel two way bind

### DIFF
--- a/mat-cascader/mat-cascader.component.ts
+++ b/mat-cascader/mat-cascader.component.ts
@@ -1,233 +1,236 @@
 import {
-    Component,
-    OnInit,
-    OnChanges,
-    AfterViewInit,
-    Input,
-    Output,
-    EventEmitter,
-    QueryList,
-    ViewChildren,
-    ElementRef,
-    forwardRef,
+  Component,
+  OnInit,
+  OnChanges,
+  AfterViewInit,
+  Input,
+  Output,
+  EventEmitter,
+  QueryList,
+  ViewChildren,
+  ElementRef,
+  forwardRef,
 } from '@angular/core';
 import {
-    IMatCascader,
-    IMatCascaderView,
-    IMatCascaderContainer,
+  IMatCascader,
+  IMatCascaderView,
+  IMatCascaderContainer,
 } from './mat-cascader.interface';
 import {
-    MatCascaderService,
+  MatCascaderService,
 } from './mat-cascader.service';
 import {
-    MatMenuTrigger,
-    MatMenu,
+  MatMenuTrigger,
+  MatMenu,
 } from '@angular/material';
-import { NgModelBase } from '../classes';
+import { NgModelBase } from './ngModel.class';
 import {
-    NG_VALUE_ACCESSOR
+  NG_VALUE_ACCESSOR
 } from '@angular/forms';
 import { cloneDeep, map } from 'lodash';
 
 @Component({
-    selector: 'ngx-mat-cascader',
-    templateUrl: './mat-cascader.component.html',
-    styleUrls: ['./mat-cascader.component.scss'],
-    providers: [
-        {
-            provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => MatCascaderComponent),
-            multi: true
-        }
-    ],
+  selector: 'ngx-mat-cascader',
+  templateUrl: './mat-cascader.component.html',
+  styleUrls: ['./mat-cascader.component.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => MatCascaderComponent),
+      multi: true
+    }
+  ],
 })
 export class MatCascaderComponent extends NgModelBase implements OnInit, AfterViewInit, OnChanges {
-    @Input()
-    data: IMatCascader[] = [];
-    @Input()
-    onlyLeaf = true;
+  @Input()
+  data: IMatCascader[] = [];
+  @Input()
+  onlyLeaf = true;
 
-    @Input()
-    get value() {
-        return this._innerValue;
+  @Input()
+  get value() {
+    return this._innerValue;
+  }
+  set value(nV) {
+    if (this._innerValue !== nV) {
+      if (!this._innerValue)
+        this._innerValue = [];
+      this._innerValue.splice(0);
+      map(nV, v => this._innerValue.push(v))
+      this.propagateChange(this._innerValue);
+      this.valueChange.emit(nV);
     }
-    set value(nV) {
-        if (this._innerValue !== nV) {
-            this._innerValue.splice(0);
-            map(nV, v => this._innerValue.push(v))
-            this.propagateChange(cloneDeep(this._innerValue));
-            this.valueChange.emit(nV);
-        }
-    }
-    @Output()
-    valueChange = new EventEmitter<(string | number)[]>();
+  }
+  @Output()
+  valueChange = new EventEmitter<(string | number)[]>();
 
-    @Input()
-    placeholder = '';
+  @Input()
+  placeholder = '';
 
-    @Input()
-    separate = ' / ';
+  @Input()
+  separate = ' / ';
 
-    valueText = '';
+  valueText = '';
 
 
-    @ViewChildren(MatMenu)
-    matMenus: QueryList<MatMenu>;
-    matMenuContainers: IMatCascaderContainer[] = [];
-    root: MatMenu | null;
+  @ViewChildren(MatMenu)
+  matMenus: QueryList<MatMenu>;
+  matMenuContainers: IMatCascaderContainer[] = [];
+  root: MatMenu | null;
 
-    constructor(
-        private _matCascaderService: MatCascaderService,
-    ) {
-        super();
-    }
+  constructor(
+    private _matCascaderService: MatCascaderService,
+  ) {
+    super();
+  }
 
 
 
-    ngOnInit() {
-        this._initContainers();
-    }
+  ngOnInit() {
+    this._initContainers();
+    this._innerValue$.subscribe(v => this._initContainers());
+  }
 
-    ngAfterViewInit() {
+  ngAfterViewInit() {
+    this._initRefs();
+  }
+
+  ngOnChanges(changes) {
+    const {
+      data,
+    } = changes;
+
+    if (data && !data.firstChange) {
+      const {
+        currentValue,
+      } = data;
+
+      this.root = null;
+      this._initContainers();
+      setTimeout(() => {
         this._initRefs();
+      });
     }
+  }
 
-    ngOnChanges(changes) {
-        const {
-            data,
-        } = changes;
+  private _initContainers() {
+    this.matMenuContainers = this._flatten(this.data);
+    this._setValueTextByValue(this.value);
+  }
 
-        if (data && !data.firstChange) {
-            const {
-                currentValue,
-            } = data;
+  private _initRefs() {
+    this.matMenuContainers.forEach(item => {
+      const el = this.matMenus.find((menu => (menu['_elementRef'] as ElementRef).nativeElement.id === item.id)) as MatMenu;
 
-            this.root = null;
-            this._initContainers();
-            setTimeout(() => {
-                this._initRefs();
-            });
-        }
-    }
-
-    private _initContainers() {
-        this.matMenuContainers = this._flatten(this.data);
-        this._setValueTextByValue(this.value);
-    }
-
-    private _initRefs() {
-        this.matMenuContainers.forEach(item => {
-            const el = this.matMenus.find((menu => (menu['_elementRef'] as ElementRef).nativeElement.id === item.id)) as MatMenu;
-
-            setTimeout(() => {
-                if (item.parent === null) {
-                    this.root = el;
-                } else {
-                    item.parent.childRef = el;
-                }
-            });
-        });
-    }
-
-    onMenuItemClick(menu: IMatCascaderView): void {
-        if (this.onlyLeaf) {
-            this._setValueOfLeaf(menu);
+      setTimeout(() => {
+        if (item.parent === null) {
+          this.root = el;
         } else {
-            this._setValueOfPath(menu);
+          item.parent.childRef = el;
         }
+      });
+    });
+  }
+
+  onMenuItemClick(menu: IMatCascaderView): void {
+    if (this.onlyLeaf) {
+      this._setValueOfLeaf(menu);
+    } else {
+      this._setValueOfPath(menu);
+    }
+  }
+
+  private _setValueOfLeaf(menu: IMatCascaderView): void {
+    if (menu.children !== undefined) {
+      return;
     }
 
-    private _setValueOfLeaf(menu: IMatCascaderView): void {
-        if (menu.children !== undefined) {
-            return;
-        }
+    this._setValueOfPath(menu);
+  }
 
-        this._setValueOfPath(menu);
+  private _setValueOfPath(menu: IMatCascaderView): void {
+    this.value = this._getValueByMenu(menu).reverse();
+    this.valueText = this._getValueTextByMenu(menu);
+  }
+
+  private _setValueTextByValue(value: (string | number)[]): void {
+    value = value || this.value;
+    if (!!value) {
+      const text = this._getTextByValue(this.data, value);
+      this.valueText = this._getValueTextByTexts(text);
     }
 
-    private _setValueOfPath(menu: IMatCascaderView): void {
-        this.value = this._getValueByMenu(menu).reverse();
-        this.valueText = this._getValueTextByMenu(menu);
+  }
+
+  private _getTextByValue(data: IMatCascader[], value: (string | number)[]): string[] {
+    const [curr, ...rest] = value;
+
+    if (!curr) {
+      return [];
     }
 
-    private _setValueTextByValue(value: (string | number)[]): void {
-        value = value || this.value;
-        if(!!value){
-            const text = this._getTextByValue(this.data, value);
-            this.valueText = this._getValueTextByTexts(text);
-        }
-            
+    const node = data.find(item => item.value === curr) as IMatCascader;
+
+    if (!node) {
+      console.log('Can not find value: ', curr, 'in: ', this);
+      return [];
     }
 
-    private _getTextByValue(data: IMatCascader[], value: (string | number)[]): string[] {
-        const [curr, ...rest] = value;
+    let result: string[] = [];
+    result.push(node.text);
 
-        if (!curr) {
-            return [];
-        }
-
-        const node = data.find(item => item.value === curr) as IMatCascader;
-
-        if (!node) {
-            console.log('Can not find value: ', curr, 'in: ', this);
-            return [];
-        }
-
-        let result: string[] = [];
-        result.push(node.text);
-
-        if (rest && node.children) {
-            result = result.concat(this._getTextByValue(node.children, rest));
-        }
-
-        return result;
+    if (rest && node.children) {
+      result = result.concat(this._getTextByValue(node.children, rest));
     }
 
-    private _getValueByMenu(menu: IMatCascaderView): (string | number)[] {
-        let _innerValue: (string | number)[] = [];
-        _innerValue.push(menu.value);
+    return result;
+  }
 
-        if (menu.container !== undefined && menu.container.parent !== null) {
-            _innerValue = _innerValue.concat(this._getValueByMenu(menu.container.parent));
-        }
+  private _getValueByMenu(menu: IMatCascaderView): (string | number)[] {
+    let _innerValue: (string | number)[] = [];
+    _innerValue.push(menu.value);
 
-        return _innerValue;
+    if (menu.container !== undefined && menu.container.parent !== null) {
+      _innerValue = _innerValue.concat(this._getValueByMenu(menu.container.parent));
     }
 
-    private _getValueTextByMenu(menu: IMatCascaderView): string {
-        let _text: string[] = [];
-        _text.push(menu.text);
+    return _innerValue;
+  }
 
-        if (menu.container !== undefined && menu.container.parent !== null) {
-            _text = _text.concat(this._getValueTextByMenu(menu.container.parent));
-        }
+  private _getValueTextByMenu(menu: IMatCascaderView): string {
+    let _text: string[] = [];
+    _text.push(menu.text);
 
-        return this._getValueTextByTexts(_text.reverse());
+    if (menu.container !== undefined && menu.container.parent !== null) {
+      _text = _text.concat(this._getValueTextByMenu(menu.container.parent));
     }
 
-    private _getValueTextByTexts(texts: string[]): string {
-        return texts.join(this.separate);
-    }
+    return this._getValueTextByTexts(_text.reverse());
+  }
 
-    private _flatten(before: IMatCascaderView[] = [], parent: IMatCascaderView | null = null): IMatCascaderContainer[] {
-        let after: IMatCascaderContainer[] = [];
+  private _getValueTextByTexts(texts: string[]): string {
+    return texts.join(this.separate);
+  }
 
-        const menu: IMatCascaderContainer = {
-            id: this._matCascaderService.id,
-            menus: before,
-            parent,
-        };
+  private _flatten(before: IMatCascaderView[] = [], parent: IMatCascaderView | null = null): IMatCascaderContainer[] {
+    let after: IMatCascaderContainer[] = [];
 
-        after.push(menu);
+    const menu: IMatCascaderContainer = {
+      id: this._matCascaderService.id,
+      menus: before,
+      parent,
+    };
 
-        before.forEach(view => {
-            view.container = menu;
+    after.push(menu);
 
-            if (view.children && Object.prototype.toString.call(view.children) === '[object Array]') {
-                after = after.concat(this._flatten(view.children, view));
-            }
-        });
+    before.forEach(view => {
+      view.container = menu;
 
-        return after;
-    }
+      if (view.children && Object.prototype.toString.call(view.children) === '[object Array]') {
+        after = after.concat(this._flatten(view.children, view));
+      }
+    });
+
+    return after;
+  }
 }

--- a/mat-cascader/ngModel.class.ts
+++ b/mat-cascader/ngModel.class.ts
@@ -8,8 +8,8 @@ export class NgModelBase implements ControlValueAccessor {
 
   set value(v: any) {
     if (v !== this._innerValue) {
-      this._innerValue = v
-      this.propagateChange(v)
+      this._innerValue = v;
+      this.propagateChange(v);
     }
   }
 
@@ -28,7 +28,5 @@ export class NgModelBase implements ControlValueAccessor {
     this.propagateChange = fn;
   }
 
-  registerOnTouched(fn: any) {
-    this.propagateChange = fn;
-  }
+  registerOnTouched(fn: any) {}
 }

--- a/mat-cascader/ngModel.class.ts
+++ b/mat-cascader/ngModel.class.ts
@@ -1,8 +1,10 @@
-import { ControlValueAccessor } from '@angular/forms'
+import { ControlValueAccessor } from '@angular/forms';
+import { Subject } from 'rxjs';
 
 export class NgModelBase implements ControlValueAccessor {
-  public propagateChange = (v: any) => {}
-  public _innerValue: any
+  public propagateChange = (v: any) => {};
+  public _innerValue: any;
+  public _innerValue$: Subject<any> = new Subject();
 
   set value(v: any) {
     if (v !== this._innerValue) {
@@ -12,20 +14,21 @@ export class NgModelBase implements ControlValueAccessor {
   }
 
   get value(): any {
-    return this._innerValue
+    return this._innerValue;
   }
 
   writeValue(v: any) {
     if (v !== this._innerValue) {
-      this._innerValue = v
+      this._innerValue = v;
+      this._innerValue$.next(v);
     }
   }
 
   registerOnChange(fn: any) {
-    this.propagateChange = fn
+    this.propagateChange = fn;
   }
 
   registerOnTouched(fn: any) {
-    this.propagateChange = fn
+    this.propagateChange = fn;
   }
 }

--- a/mat-cascader/ngModel.class.ts
+++ b/mat-cascader/ngModel.class.ts
@@ -1,0 +1,31 @@
+import { ControlValueAccessor } from '@angular/forms'
+
+export class NgModelBase implements ControlValueAccessor {
+  public propagateChange = (v: any) => {}
+  public _innerValue: any
+
+  set value(v: any) {
+    if (v !== this._innerValue) {
+      this._innerValue = v
+      this.propagateChange(v)
+    }
+  }
+
+  get value(): any {
+    return this._innerValue
+  }
+
+  writeValue(v: any) {
+    if (v !== this._innerValue) {
+      this._innerValue = v
+    }
+  }
+
+  registerOnChange(fn: any) {
+    this.propagateChange = fn
+  }
+
+  registerOnTouched(fn: any) {
+    this.propagateChange = fn
+  }
+}


### PR DESCRIPTION
support two-way data bind by ngModel:
 ```
<ngx-mat-cascader [data]='cascaderData' [(ngModel)]='value' (ngModelChange)='onCascaderChange($event)'></ngx-mat-cascader>

<ngx-mat-cascader formControlName='street' [data]='cascaderData'></ngx-mat-cascader>
``` 

Data bind by [(value)] is also compatible.
```
<ngx-mat-cascader  [data]='cascaderData' [(value)]='value'></ngx-mat-cascader>
```